### PR TITLE
Support Dark Mode

### DIFF
--- a/src/org.xtuml.bp.core/src/org/xtuml/bp/core/util/UIUtil.java
+++ b/src/org.xtuml.bp.core/src/org/xtuml/bp/core/util/UIUtil.java
@@ -806,4 +806,29 @@ public class UIUtil
 		}
 
 	}
+
+	public static boolean isDarkTheme() {
+		// get the current workbench theme, set defaults accordingly
+		// NOTE, we could import the swt css libraries but they are not
+		// considered API and access is discouraged. Instead of adding
+		// the dependencies we just use reflection, worse case is we
+		// revert to light mode
+		if(CoreUtil.IsRunningHeadless) {
+			return false;
+		}
+		Object data = PlatformUI.getWorkbench().getDisplay().getData("org.eclipse.e4.ui.css.swt.theme");
+		if (data != null) {
+			try {
+				Method currentTheme = data.getClass().getMethod("getActiveTheme", new Class[0]);
+				Object theme = currentTheme.invoke(data, new Object[0]);
+				Method getLabel = theme.getClass().getMethod("getLabel", new Class[0]);
+				String label = (String) getLabel.invoke(theme, new Object[0]);
+				return label.equals("Dark");
+			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
+				// ignore
+			}
+		}
+		return false;
+	}
 }

--- a/src/org.xtuml.bp.io.core/arc/gen_import_java.inc
+++ b/src/org.xtuml.bp.io.core/arc/gen_import_java.inc
@@ -505,7 +505,7 @@ public class ${class_name} extends CoreImport
             IPath projLoc = null;
                 projLoc = file.getProject().getLocation();
                 if (projLoc.isPrefixOf(curPath)) {
-                    projRelPath = curPath.removeFirstSegments(projLoc.segmentCount() - 1);
+                    projRelPath = file.getFullPath();
                 }
         }
     }

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/Activator.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/Activator.java
@@ -17,6 +17,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.xtuml.bp.core.CorePlugin;
 import org.xtuml.bp.core.common.TransactionManager;
+import org.xtuml.bp.core.util.UIUtil;
 import org.xtuml.bp.ui.graphics.factories.AdapterFactory;
 import org.xtuml.bp.ui.graphics.listeners.GraphicalPasteListener;
 import org.xtuml.bp.ui.graphics.listeners.GraphicsModelTransactionListener;
@@ -118,6 +119,10 @@ public class Activator extends AbstractUIPlugin {
 		}
 	}
 
+	public boolean isDarkTheme() {
+		return UIUtil.isDarkTheme();
+	}
+	
 	ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
 	public Color getColor(int red, int green, int blue) {
 		String symbolicName = red + ":" + green + ":" + blue;

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/figures/DecoratedPolylineConnection.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/figures/DecoratedPolylineConnection.java
@@ -194,7 +194,11 @@ public class DecoratedPolylineConnection extends PolylineConnection implements
 		} else {
 			// ensure black for line color, as the hidden layer
 			// when shown for some reason switches to white
-			g.setForegroundColor(ColorConstants.black);
+			if(Activator.getDefault().isDarkTheme()) {
+				g.setForegroundColor(ColorConstants.white);
+			} else {
+				g.setForegroundColor(ColorConstants.black);
+			}
 		}
 		// if the client says this element is to be highlighted
 		// do that here

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/figures/ShapeImageFigure.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/figures/ShapeImageFigure.java
@@ -76,6 +76,9 @@ public class ShapeImageFigure extends RectangleFigure implements IMapMode {
 			return;
 		}
 		Color defaultColor = specification.getInternal();
+		if(Activator.getDefault().isDarkTheme()) {
+			defaultColor = Activator.getDefault().getColor(81, 86, 88);
+		}
 		Linecolorstyle_c lcs = null;
 		Fillcolorstyle_c fcs = Fillcolorstyle_c
 				.getOneSTY_FCSOnR400(Elementstyle_c

--- a/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/parts/DiagramEditPart.java
+++ b/src/org.xtuml.bp.ui.graphics/src/org/xtuml/bp/ui/graphics/parts/DiagramEditPart.java
@@ -185,7 +185,7 @@ public class DiagramEditPart extends AbstractGraphicalEditPart implements
 		if(mdlSpec == null) {
 			return ColorConstants.white;
 		}
-		return mdlSpec.getBackground();
+		return Activator.getDefault().isDarkTheme() ? Activator.getDefault().getColor(47,47,47) : mdlSpec.getBackground();
 	}
 
 	@Override

--- a/src/org.xtuml.bp.ui.text/src/org/xtuml/bp/ui/text/OALEditorConstants.java
+++ b/src/org.xtuml.bp.ui.text/src/org/xtuml/bp/ui/text/OALEditorConstants.java
@@ -35,11 +35,16 @@ public class OALEditorConstants {
     public static final RGB DEFAULT_BACKGROUND = new RGB(255,255,255);
     public static final boolean DEFAULT_BACKGROUND_ISSYSTEMDEFAULT = true;
     
-    public static final RGB DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT = new RGB(63, 127, 95);
-    public static final RGB DEFAULT_FOREGROUND_MULTI_LINE_COMMENT = new RGB(63, 127, 95);
-    public static final RGB DEFAULT_FOREGROUND_KEYWORD = new RGB(127, 0, 85);
-    public static final RGB DEFAULT_FOREGROUND_STRING = new RGB(42, 0, 255);
-    public static final RGB DEFAULT_FOREGROUND_OTHER = new RGB(0,0,0);
+    public static final RGB DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT_LIGHT = new RGB(63, 127, 95);
+    public static final RGB DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT_DARK = new RGB(255, 163, 72);
+    public static final RGB DEFAULT_FOREGROUND_MULTI_LINE_COMMENT_LIGHT = new RGB(63, 127, 95);
+    public static final RGB DEFAULT_FOREGROUND_MULTI_LINE_COMMENT_DARK = new RGB(205, 171, 143);
+    public static final RGB DEFAULT_FOREGROUND_KEYWORD_LIGHT = new RGB(127, 0, 85);
+    public static final RGB DEFAULT_FOREGROUND_KEYWORD_DARK = new RGB(87, 227, 137);
+    public static final RGB DEFAULT_FOREGROUND_STRING_LIGHT = new RGB(42, 0, 255);
+    public static final RGB DEFAULT_FOREGROUND_STRING_DARK = new RGB(248, 228, 92);
+    public static final RGB DEFAULT_FOREGROUND_OTHER_LIGHT = new RGB(0,0,0);
+    public static final RGB DEFAULT_FOREGROUND_OTHER_DARK = new RGB(255, 255, 255);
     
     public static final int  DEFAULT_STYLE_SINGLE_LINE_COMMENT = SWT.NULL;
     public static final int  DEFAULT_STYLE_MULTI_LINE_COMMENT = SWT.BOLD;

--- a/src/org.xtuml.bp.ui.text/src/org/xtuml/bp/ui/text/editor/SyntaxHighlightingPreferencesStore.java
+++ b/src/org.xtuml.bp.ui.text/src/org/xtuml/bp/ui/text/editor/SyntaxHighlightingPreferencesStore.java
@@ -29,7 +29,7 @@ import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
-
+import org.xtuml.bp.core.util.UIUtil;
 import org.xtuml.bp.ui.preference.BasePlugin;
 import org.xtuml.bp.ui.preference.IPreferenceModel;
 import org.xtuml.bp.ui.preference.IPreferenceModelStore;
@@ -53,7 +53,7 @@ public class SyntaxHighlightingPreferencesStore implements IPreferenceModelStore
     private static String TOKEN_FOREGROUND = PREFIX + "token_foreground";
     private static String TOKEN_IS_BOLD = PREFIX + "token_is_bold";
 
-    public Class getModelClass() {
+    public Class<?> getModelClass() {
         return SyntaxHighlightingPreferences.class;
     }
 
@@ -125,7 +125,7 @@ public class SyntaxHighlightingPreferencesStore implements IPreferenceModelStore
 
         return prefs;
     }
-
+    
     public void restoreModelDefaults(IPreferenceModel model) {
 
         if (model == null)
@@ -135,37 +135,39 @@ public class SyntaxHighlightingPreferencesStore implements IPreferenceModelStore
         }
 
         SyntaxHighlightingPreferences prefs = (SyntaxHighlightingPreferences) model;
+        
+        boolean dark = UIUtil.isDarkTheme();
 
         prefs.setBackgroundRGB(OALEditorConstants.DEFAULT_BACKGROUND, OALEditorConstants.DEFAULT_BACKGROUND_ISSYSTEMDEFAULT);
 
         prefs.setTextAttribute(
             ActionLanguageTokenTypes.TOKEN_TYPE_single_line_comment,
             OALEditorConstants.DEFAULT_LABEL_SINGLE_LINE_COMMENT,
-            OALEditorConstants.DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT,
+            dark ? OALEditorConstants.DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT_DARK : OALEditorConstants.DEFAULT_FOREGROUND_SINGLE_LINE_COMMENT_LIGHT,
             null,
             OALEditorConstants.DEFAULT_STYLE_SINGLE_LINE_COMMENT);
         prefs.setTextAttribute(
             ActionLanguageTokenTypes.TOKEN_TYPE_multi_line_comment,
             OALEditorConstants.DEFAULT_LABEL_MULTI_LINE_COMMENT,
-            OALEditorConstants.DEFAULT_FOREGROUND_MULTI_LINE_COMMENT,
+            dark ? OALEditorConstants.DEFAULT_FOREGROUND_MULTI_LINE_COMMENT_DARK : OALEditorConstants.DEFAULT_FOREGROUND_MULTI_LINE_COMMENT_LIGHT,
             null,
             OALEditorConstants.DEFAULT_STYLE_MULTI_LINE_COMMENT);
         prefs.setTextAttribute(
             ActionLanguageTokenTypes.TOKEN_TYPE_string,
             OALEditorConstants.DEFAULT_LABEL_STRING,
-            OALEditorConstants.DEFAULT_FOREGROUND_STRING,
+            dark ? OALEditorConstants.DEFAULT_FOREGROUND_STRING_DARK : OALEditorConstants.DEFAULT_FOREGROUND_STRING_LIGHT,
             null,
             OALEditorConstants.DEFAULT_STYLE_STRING);
         prefs.setTextAttribute(
             ActionLanguageTokenTypes.TOKEN_TYPE_keyword,
             OALEditorConstants.DEFAULT_LABEL_KEYWORD,
-            OALEditorConstants.DEFAULT_FOREGROUND_KEYWORD,
+            dark ? OALEditorConstants.DEFAULT_FOREGROUND_KEYWORD_DARK : OALEditorConstants.DEFAULT_FOREGROUND_KEYWORD_LIGHT,
             null,
             OALEditorConstants.DEFAULT_STYLE_KEYWORD);
         prefs.setTextAttribute(
             ActionLanguageTokenTypes.TOKEN_TYPE_other,
             OALEditorConstants.DEFAULT_LABEL_OTHER,
-            OALEditorConstants.DEFAULT_FOREGROUND_OTHER,
+            dark ? OALEditorConstants.DEFAULT_FOREGROUND_OTHER_DARK : OALEditorConstants.DEFAULT_FOREGROUND_OTHER_LIGHT,
             null,
             OALEditorConstants.DEFAULT_STYLE_OTHER);
     }


### PR DESCRIPTION
Current implementation looks at the current theme and
applies default colors accordingly.

NOTE: These changes do not listen for theme changes, but
we already get a notification from eclipse to restart before
changes take full effect.  Later support could be extended
to adjust when the theme changes.

Old workspaces will consider the previous defaults as user
configured due to the ui.text design.  New workspaces can be
created or in the OAL editor preferences "Restore Defaults"
can be used.

Graphics also uses a new default color scheme when dark mode
is used.

Support projects named differently than actual folder structure.

Eclipse allows you to name a project independently of the folder
on disk.  When you have this situattion Import Model Component
will create unresolvable proxies.  This can create an issue with
many areas of the tool, but the one being fixed here is that global
types are not available as the results are added to the proxy and
not the real element.  There is only one line that needs changing
to address this issue and in that case we were taking an eclipse
resource an converting it to a filesystem object.  This was unneccesary
as the full path of the resource object is the exact path we need.